### PR TITLE
Fix compatibility with PyQt5 >=5.11 and PyQt4 >= 4.12.2

### DIFF
--- a/krop/config.py
+++ b/krop/config.py
@@ -2,16 +2,17 @@ import sys
 
 PYQT5 = False
 try:
-    import sip
     # use PyQt5 unless not available or specified otherwise
     if '--no-qt5' not in sys.argv:
         try:
-            import PyQt5
+            from PyQt5 import QtCore
+            import sip
             PYQT5 = True
         except ImportError:
             pass
     if not PYQT5:
-        import PyQt4
+        from PyQt4 import QtCore
+        import sip
 except ImportError:
     _msg = "Please install PyQt4 or PyQt5 first."
     raise RuntimeError(_msg)


### PR DESCRIPTION
Since those two versions PyQt uses a private copy of the sip module.
This results in an error when trying to start krop:
"ModuleNotFoundError: No module named 'sip'". According to the
documentation [1][2] including any PyQt module before importing sip
works with both versions.

[1] https://www.riverbankcomputing.com/static/Docs/PyQt5/incompatibilities.html#pyqt-v5-11
[2] https://www.riverbankcomputing.com/static/Docs/PyQt4/incompatibilities.html#pyqt-v4-12-2