### PR TITLE
fix import for PyPDF2 3

### DIFF
--- a/krop/pdfcropper.py
+++ b/krop/pdfcropper.py
@@ -278,7 +278,7 @@ if '--use-pikepdf' in sys.argv:
 # use PyPDF2 if requested
 if '--use-pypdf2' in sys.argv:
     try:
-        from PyPDF2 import PdfFileReader as PdfReader, PdfFileWriter as PdfWriter
+        from PyPDF2 import PdfReader, PdfWriter
         lib_crop = PYPDF2
     except ImportError:
         print("PyPDF2 was requested but failed to load.", file=sys.stderr)
@@ -294,7 +294,7 @@ if not lib_crop:
     # otherwise use PyPDF2
     if not lib_crop:
         try:
-            from PyPDF2 import PdfFileReader as PdfReader, PdfFileWriter as PdfWriter
+            from PyPDF2 import PdfReader, PdfWriter
             lib_crop = PYPDF2
         except ImportError:
             pass
@@ -334,11 +334,15 @@ elif lib_crop == PIKEPDF:
     PdfFile = PikePdfFile
     PdfCropper = PikePdfCropper
     print("Using pikepdf for cropping.", file=sys.stderr)
-elif lib_crop == PYPDF1 or lib_crop == PYPDF2:
-    # PyPDF2 and the old pyPdf use a naming scheme different from the new pypdf
+elif lib_crop == PYPDF1:
+    # old pyPdf has camelCase API, new pypdf has snake_case API
     PdfFile = PyPdfOldFile
     PdfCropper = PyPdfOldCropper
-    print("Using " + (lib_crop == PYPDF2 and "PyPDF2" or "pyPdf") + " for cropping.", file=sys.stderr)
+    print("Using pyPdf for cropping.", file=sys.stderr)
+elif lib_crop == PYPDF2:
+    PdfFile = PyPdfFile
+    PdfCropper = PyPdfCropper
+    print("Using PyPDF2 for cropping.", file=sys.stderr)
 else:
     PdfFile = PyPdfFile
     PdfCropper = PyPdfCropper


### PR DESCRIPTION
fix build with PyPDF2 version 3, which has switched to camel_case API

downstream issue https://github.com/NixOS/nixpkgs/issues/226012

> PyPDF2.errors.DeprecationError: PdfFileReader is deprecated and was removed in PyPDF2 3.0.0. Use PdfReader instead.

similar PR https://github.com/4ft35t/email2pdf/pull/4

this could be made backward-compatible with PyPDF2 version 2 with `PyPDF2.__version__.startswith("2.")`