### PR TITLE
feat: add 'current' page keyword

### DIFF
--- a/krop/mainwindow.py
+++ b/krop/mainwindow.py
@@ -364,6 +364,10 @@ class MainWindow(QMainWindow):
         for i in intervals:
             a,b = i[0], i[-1]
             if a:
+                if a == 'current':
+                    a = self.viewer.currentPageIndex + 1
+                if b == 'current':
+                    b = self.viewer.currentPageIndex + 1
                 if not b: b = self.viewer.numPages()
                 pages.extend(range(int(a)-1,int(b))) # subtract 1 because pages are counted from 0 internally
         return pages


### PR DESCRIPTION
This PR introduces support for the special keyword `current` in the page selection textbox.

When specified, it automatically selects the currently viewed page for export.
This addition streamlines workflows that involve cropping or extracting figures or algorithms from an individual page.
This feature is particularly useful in literature knowledge base tasks,
as repetitive manual input of the current page number can be tedious and error-prone.

